### PR TITLE
Updating Rule Sets to incoporate Threat Intelligence

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@ default['threatstack']['version'] = nil
 default['threatstack']['pkg_action'] = :install
 # If no rulesets are specified the agent will register to the default
 # rule set, according to a comment in recipes/default.rb
-default['threatstack']['rulesets'] = []
+default['threatstack']['rulesets'] = ['Base Rule Set', 'Threat Intelligence Rule Set']
 default['threatstack']['hostname'] = nil
 default['threatstack']['ignore_failure'] = true
 


### PR DESCRIPTION
This PR is to will update threatstack agents on the boxes to deploy with the new threatstack feature called "cloud security platform" 